### PR TITLE
[Refactor] Add a Border class

### DIFF
--- a/jigsolver/__init__.py
+++ b/jigsolver/__init__.py
@@ -1,2 +1,2 @@
-from .puzzle import Board, Piece, Puzzle, Slot
+from .puzzle import Board, Border, Piece, Puzzle, Slot
 from .random_solver import random_solver

--- a/sandbox.ipynb
+++ b/sandbox.ipynb
@@ -36,7 +36,7 @@
     "plt.title('Example of a Piece')\n",
     "plt.show()\n",
     "\n",
-    "plt.imshow(P.bottom)\n",
+    "plt.imshow([P.get_border(Border.BOTTOM)])\n",
     "plt.title('Bottom border of the piece')"
    ]
   },
@@ -119,6 +119,15 @@
     "for slot in eiffel_unsolved.board.neighbors(3,2):\n",
     "    print(slot)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eiffel_unsolved.get_compatibilities()[0][0]"
+   ]
   }
  ],
  "metadata": {
@@ -137,7 +146,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.6-final"
   }
  },
  "nbformat": 4,

--- a/tests/border_test.py
+++ b/tests/border_test.py
@@ -1,0 +1,47 @@
+import numpy as np
+import unittest
+from jigsolver import Border
+
+class BorderTestCase(unittest.TestCase):
+    def setUp(self):
+        self.grid = np.array([
+            [11, 21, 31],
+            [12, 22, 32],
+            [13, 23, 33],
+        ])
+
+    def test_border_top_should_return_top_border(self):
+        top = [11, 21, 31]
+        self.assertListEqual(list(self.grid[Border.TOP.slice]), top)
+    
+    def test_border_bottom_should_return_bottom_border(self):
+        bottom = [13, 23, 33]
+        self.assertListEqual(list(self.grid[Border.BOTTOM.slice]), bottom)
+    
+    def test_border_right_should_return_right_border(self):
+        right = [31, 32, 33]
+        self.assertListEqual(list(self.grid[Border.RIGHT.slice]), right)
+    
+    def test_border_left_should_return_left_border(self):
+        left = [11, 12, 13]
+        self.assertListEqual(list(self.grid[Border.LEFT.slice]), left)
+
+class OppositeBorderTestCase(unittest.TestCase):
+    def test_border_top_opposite_should_return_bottom(self):
+        self.assertEqual(Border.TOP.opposite, Border.BOTTOM)
+    
+    def test_border_bottom_opposite_should_return_top(self):
+        self.assertEqual(Border.BOTTOM.opposite, Border.TOP)
+    
+    def test_border_right_opposite_should_return_left(self):
+        self.assertEqual(Border.RIGHT.opposite, Border.LEFT)
+    
+    def test_border_left_opposite_should_return_right(self):
+        self.assertEqual(Border.LEFT.opposite, Border.RIGHT)
+
+    def test_border_opposite_twice_should_return_same_border(self):
+        self.assertEqual(Border.RIGHT.opposite.opposite, Border.RIGHT) 
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/piece_test.py
+++ b/tests/piece_test.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-from jigsolver.puzzle import Piece,Puzzle
+from jigsolver import Border, Piece, Puzzle
 
 class PieceTestCase(unittest.TestCase):
     def setUp(self):
@@ -42,10 +42,20 @@ class PieceTestCase(unittest.TestCase):
         B = np.ones((3, 3, 3))
         B[1, 0] = 150
         B[1, 2] = 200
-        B=Piece(B)
+        B = Piece(B)
 
-        self.assertEqual(A.diss(B), {'L': 178206, 'R': 155706, 'U': 356409, 'B': 88209})
-        self.assertEqual(B.diss(A), {'L': 155706, 'R': 178206, 'U': 88209, 'B': 356409})
+        diss = {
+            Border.TOP: 356409,
+            Border.BOTTOM: 88209,
+            Border.RIGHT: 155706,
+            Border.LEFT: 178206
+        }
+
+        self.assertDictEqual(A.diss(B), diss)
+
+        diss[Border.TOP], diss[Border.BOTTOM] = diss[Border.BOTTOM], diss[Border.TOP]
+        diss[Border.LEFT], diss[Border.RIGHT] = diss[Border.RIGHT], diss[Border.LEFT]
+        self.assertDictEqual(B.diss(A), diss)
 
 
 if __name__ == '__main__':

--- a/tests/puzzle_test.py
+++ b/tests/puzzle_test.py
@@ -1,5 +1,5 @@
 import unittest
-from jigsolver.puzzle import Puzzle, Board, Slot
+from jigsolver import Puzzle, Board, Slot
 import numpy as np
 from copy import copy
 import matplotlib.pyplot as plt
@@ -15,7 +15,7 @@ class PuzzleTestCase(unittest.TestCase):
         self.eiffel_puzzle.create_from_img(img_real)
     
     def test_puzzle_create_piece_size(self):
-        return self.assertEqual(self.eiffel_puzzle.board[0,0].size, 100)
+        self.assertEqual(self.eiffel_puzzle.board[0,0].size, 100)
 
     def test_create_puzzle_crop_test(self):
         self.assertEqual(self.puzzle.shape,(4,4))


### PR DESCRIPTION
This PR introduced a new class `Border`. Inheriting from the python `Enum` class, its purpose is to bound the symbolic names of the 4 borders to unique constant values. Thus the `Border` class provides the convention to read/write quadruplets corresponding to borders. For example if `c = [0.5, 0.9, 0.1, 0.2]` stores the compatibilityies between two given pieces, `d[Border.TOP.value]` corresponds to the value of the compatibility when the first piece is placed above the second piece.

The following for borders are defined:

0. `Border.TOP`
1. `Border.RIGHT`
2. `Border.BOTTOM`
3. `Border.LEFT`

Whose attributes are:
* `value`
* `slice` returns the slice of the corresponding border in an array. (e.g. `piece.picture[Border.LEFT.slice]` or `puzzle.board[Border.RIGHT.slice]`)
* `opposite` returns the opposite `Border` (e.g. `Border.TOP.opposite` is `Border.LEFT`)
